### PR TITLE
fixing markdown lint GitHub Action

### DIFF
--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -14,9 +14,12 @@ jobs:
     steps:
     - uses: actions/checkout@v1
 
+    # installing more packages as proposed in 
+    # https://askubuntu.com/questions/1088662/npm-depends-node-gyp-0-10-9-but-it-is-not-going-to-be-installed
     - name: install markdownlint-cli
       run: |
-        sudo apt-get install npm
+        sudo apt-get update       
+        sudo apt-get install -y npm sudo nodejs-dev node-gyp libssl1.0-dev
         npm install markdownlint-cli
 
     - name: lint markdown files


### PR DESCRIPTION
The GitHub Action on linting our markdown had issues with installing the `npm` package. 

I resolved it using the solution from https://askubuntu.com/questions/1088662/npm-depends-node-gyp-0-10-9-but-it-is-not-going-to-be-installed

Same problem as https://github.com/ChristianKuehnel/iwg-workspace/pull/30