### PR TITLE
Add long tail relicensing page

### DIFF
--- a/content/docs/relicensing.md
+++ b/content/docs/relicensing.md
@@ -60,13 +60,14 @@ We also have worked with our legal counsel to build several more boring pieces:
 * A corporate agreement to relicense that is available for companies to sign
   and has begun to be distributed to some of the known and/or large contributors
 
-We have installed the new developer policy and added the new license on January
-19th 2019 after the LLVM 8.0 release had branched.
+The new license was added and changes to the developer policy were completed on
+January 19, 2019 after the LLVM 8.0 release was branched.
 
 We are currently collecting relicensing agreements from copyright holders of
 contributions before 19th of January 2019. While we already have well over 90%
-of code covered, we are still working through the long tail. Help is very much
-appreciated with that. Please have a look at our
+of code covered, we are still working through the long tail. We are seeking
+volunteers to help us reach individuals and corporations who have not signed the
+relicense agreements. For full details on how to help, please see our
 [long tail relicensing page](({{< relref "/docs/relicensing_long_tail" >}})) for
 more details.
 

--- a/content/docs/relicensing.md
+++ b/content/docs/relicensing.md
@@ -60,19 +60,22 @@ We also have worked with our legal counsel to build several more boring pieces:
 * A corporate agreement to relicense that is available for companies to sign
   and has begun to be distributed to some of the known and/or large contributors
 
-We currently plan to install the new developer policy and add the new license in
-January 2019 after the LLVM 8.0 release has branched.
+We have installed the new developer policy and added the new license on January
+19th 2019 after the LLVM 8.0 release had branched.
 
-Once that is done, we will still need need to:
+We are currently collecting relicensing agreements from copyright holders of
+contributions before 19th of January 2019. While we already have well over 90%
+of code covered, we are still working through the long tail. Help is very much
+appreciated with that. Please have a look at our
+[long tail relicensing page](({{< relref "/docs/relicensing_long_tail" >}})) for
+more details.
 
-* Enact a process for getting 100% of existing code relicensed with the above
-  agreements or rewrite/remove the code
-* Drop the old license when the entire codebase is covered under the new
-  license
+Once the codebase is fully covered by the new license, we'll drop the old
+license.
 
 ## New File Header
 
-The new file header will be:
+The new file header is:
 
     //===-- file/name - File description ----------------------------\*- C++ -\*-===//
     //
@@ -95,7 +98,7 @@ Some notable aspects of the new header:
 ## Individual Relicensing Agreement
 
 Individuals need to complete [a web
-form](https://goo.gl/forms/X4HiyYRcRHOnTSvC3) that we will use to drive the
+form](https://goo.gl/forms/X4HiyYRcRHOnTSvC3) that we use to drive the
 relicensing process. Part of that form will prompt them with a DocuSign
 agreement that they can sign online to cover anything they personally
 contributed. It will also collect any companies or academic institutions that
@@ -103,12 +106,7 @@ may own right to some of their contributions so that we can cover them with the
 corporate agreement below.
 
 We do ask that individuals generally sign the individual agreement even if they
-think their contributions are probably covered by a corporate agreement. It will
-be fairly expensive for us to validate each case where an individual has not
-signed that \*all\* of their contributions are covered by a corporate
-agreement. The individual agreements let us not spend time and money on this by
-covering things either way. We think this is likely simpler and definitely less
-expensive. Still, we are leaving all of the options open.
+think their contributions are probably covered by a corporate agreement.
 
 Feel free to send questions concerns about this to the [Foundation mailing
 list](mailto://llvm-foundation@lists.llvm.org).
@@ -215,23 +213,3 @@ things signed and set up.
 * Samsung
 
 {{< /expand >}}
-
-## Next Steps and Schedule Estimate
-
-Our goal is to openly and transparently communicate our process, including the
-expected next steps and a timeframe that can be used for planning. That said, we
-are dealing with a lot of unknowns, so while we believe the following schedule
-is achievable, this is not a guarantee:
-
-* ~January 2019: Coincident with the final release branch date for LLVM 8.0,
-  we will install the new developer policy. To ensure that all contributors
-  have agreed to the terms of the new developer policy, we will rescind commit
-  access from all contributors who are not covered by a corporate or
-  individual agreement at that point. We will develop a policy for affected
-  contributors to regain commit access.
-
-When these steps are done, all new contributions will be under the new license
-structure, and we expect that a significant amount of prior contributions will
-be relicensed under the new structure. At that point, we will scope and define
-the process for chasing down the long tail of prior contributions that are not
-covered and resolve them on a case-by-case basis.

--- a/content/docs/relicensing_long_tail.md
+++ b/content/docs/relicensing_long_tail.md
@@ -1,0 +1,45 @@
+---
+title: Relicensing Long Tail
+bookToc: true
+---
+
+# LLVM Relicensing: Long tail of individuals and corporations without an agreement yet
+
+The LLVM relicensing effort is currently at the stage where we collect
+agreements from individuals and corporations owning the copyright of
+contributions before 19th of January 2019.
+
+We already have agreements in place for the far majority of contributions.  We
+still have a long tail of both individuals and corporations we'd like to get
+agreements from.
+
+The list of individuals and corporations we'd still like to get agreements from
+is regularly updated in a
+[spreadsheet](https://docs.google.com/spreadsheets/d/18_0Hog_eSwES8lKwf7WJal3yBwwcYfvPu1yCfZnTcek/edit?usp=sharing).
+Please have a look to see if you know any of them and could help with reaching
+out to them, asking them to agree with relicensing the contributions they own
+the copyright on.
+
+## Individuals
+
+When reaching out to an individual, please ask them to complete [this web
+form](https://goo.gl/forms/X4HiyYRcRHOnTSvC3). Part of that form will prompt
+them with a DocuSign agreement that they can sign online to cover anything they
+personally contributed. The web form will also collect any companies or academic
+institutions that may own rights to some of their contributions so that we can
+cover them with the corporate agreement below.
+
+We do ask that individuals generally sign the individual agreement even if they
+think their contributions are covered by a corporate agreement.
+
+
+## Corporations
+
+When you do reach out to a corporation, please do let us know at
+license-questions@llvm.org. Corporations can sign the agreement to relicense
+their contributions to LLVM under the new license
+[with DocuSign](https://na3.docusign.net/Member/PowerFormSigning.aspx?PowerFormId=5a2bb38c-41c4-4ce0-a26e-52a7eb8ae51c).
+This is our preferred mechanism for collecting signatures.
+
+If you have any questions, remarks or suggestions, please contact us at
+license-questions@llvm.org.

--- a/content/docs/relicensing_long_tail.md
+++ b/content/docs/relicensing_long_tail.md
@@ -28,6 +28,10 @@ them with a DocuSign agreement that they can sign online to cover anything they
 personally contributed. The web form will also collect any companies or academic
 institutions that may own rights to some of their contributions so that we can
 cover them with the corporate agreement below.
+If for any reason they cannot sign the DocuSign agreement, we also accept an
+email sent to license-questions@llvm.org in which they explicitly agree to offer
+their past contributions to LLVM under the Apache 2.0 WITH LLVM exception
+license.
 
 We do ask that individuals generally sign the individual agreement even if they
 think their contributions are covered by a corporate agreement.

--- a/content/docs/relicensing_long_tail.md
+++ b/content/docs/relicensing_long_tail.md
@@ -3,7 +3,7 @@ title: Relicensing Long Tail
 bookToc: true
 ---
 
-# LLVM Relicensing: Long tail of individuals and corporations without an agreement yet
+# Long tail of individuals and corporations without a relicensing agreement yet
 
 The LLVM relicensing effort is currently at the stage where we collect
 agreements from individuals and corporations owning the copyright of
@@ -31,7 +31,6 @@ cover them with the corporate agreement below.
 
 We do ask that individuals generally sign the individual agreement even if they
 think their contributions are covered by a corporate agreement.
-
 
 ## Corporations
 

--- a/content/menu/index.md
+++ b/content/menu/index.md
@@ -7,6 +7,7 @@ headless: true
 - [Public Documents]({{< relref "/docs/public-docs" >}})
 - [Sponsors]({{< relref "/docs/sponsors" >}})
 - [Relicensing]({{< relref "/docs/relicensing" >}})
+  - [Long tail]({{< relref "/docs/relicensing_long_tail" >}})
 - [Renaming]({{< relref "/docs/branch-rename" >}})
 - [Infrastructure]({{< relref "/docs/infrastructure-wg" >}})
 


### PR DESCRIPTION
Also remove/adapt out-dated information from the main relicensing page.